### PR TITLE
Fix EOL Bug

### DIFF
--- a/dist/Shell.js
+++ b/dist/Shell.js
@@ -1,10 +1,10 @@
 /*********************************************************
- * node-powershell - Certainly the easiest way to run PowerShell from your NodeJS app
- * @version v3.1.0
+ * node-powershell - Easily run PowerShell from your NodeJS app
+ * @version v3.1.1
  * @link http://rannn505.github.io/node-powershell/
  * @copyright Copyright (c) 2017 Ran Cohen <rannn505@outlook.com>
  * @license MIT (http://www.opensource.org/licenses/mit-license.php)
- * @Compiled At: 2017-03-02
+ * @Compiled At: 2017-9-1
   *********************************************************/
 'use strict';
 
@@ -36,7 +36,7 @@ var IS_WIN = os.platform() === 'win32';
 var MODULE_MSG = colors.bold.blue('NPS> ');
 var OK_MSG = colors.green;
 var ERROR_MSG = colors.red;
-var EOI = 'EOI';
+var EOI = '4ab5852ddbe5489dbbb4249b3b032ce4';
 
 /**
  * The Shell class.
@@ -104,6 +104,12 @@ var Shell = exports.Shell = function (_eventEmitter) {
 
     _this._proc.stdout.on('data', function (data) {
       if (data.indexOf(EOI) !== -1) {
+        if (data.indexOf(os.EOL + EOI)) {
+          var correctedData = data.replace(os.EOL + EOI, '');
+          _this.emit('output', correctedData);
+          _output.push(correctedData);
+        }
+
         _this.emit(_type, _output.join(''));
         _output = [];
         _type = '_resolve';

--- a/dist/Shell.js
+++ b/dist/Shell.js
@@ -104,7 +104,7 @@ var Shell = exports.Shell = function (_eventEmitter) {
 
     _this._proc.stdout.on('data', function (data) {
       if (data.indexOf(EOI) !== -1) {
-        if (data.indexOf(os.EOL + EOI)) {
+        if (data.indexOf(os.EOL + EOI) !== -1) {
           var correctedData = data.replace(os.EOL + EOI, '');
           _this.emit('output', correctedData);
           _output.push(correctedData);

--- a/dist/Shell.js
+++ b/dist/Shell.js
@@ -4,7 +4,7 @@
  * @link http://rannn505.github.io/node-powershell/
  * @copyright Copyright (c) 2017 Ran Cohen <rannn505@outlook.com>
  * @license MIT (http://www.opensource.org/licenses/mit-license.php)
- * @Compiled At: 2017-9-1
+ * @Compiled At: 2017-9-4
   *********************************************************/
 'use strict';
 
@@ -104,8 +104,14 @@ var Shell = exports.Shell = function (_eventEmitter) {
 
     _this._proc.stdout.on('data', function (data) {
       if (data.indexOf(EOI) !== -1) {
-        if (data.indexOf(os.EOL + EOI) !== -1) {
-          var correctedData = data.replace(os.EOL + EOI, '');
+        // noticed a strange bug the occationally instead of getting the \r\n that was expected on Windows I would only get \n
+        // from what I could tell using Write-Host would produce only a \n about 95% of the time but echo always produced \r\n
+        if (data.indexOf("\r\n" + EOI) !== -1) {
+          var correctedData = data.replace("\r\n" + EOI, '');
+          _this.emit('output', correctedData);
+          _output.push(correctedData);
+        } else if (data.indexOf("\n" + EOI) !== -1) {
+          var correctedData = data.replace("\n" + EOI, '');
           _this.emit('output', correctedData);
           _output.push(correctedData);
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,10 +1,10 @@
 /*********************************************************
- * node-powershell - Certainly the easiest way to run PowerShell from your NodeJS app
- * @version v3.1.0
+ * node-powershell - Easily run PowerShell from your NodeJS app
+ * @version v3.1.1
  * @link http://rannn505.github.io/node-powershell/
  * @copyright Copyright (c) 2017 Ran Cohen <rannn505@outlook.com>
  * @license MIT (http://www.opensource.org/licenses/mit-license.php)
- * @Compiled At: 2017-03-02
+ * @Compiled At: 2017-9-1
   *********************************************************/
 'use strict';
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -4,7 +4,7 @@
  * @link http://rannn505.github.io/node-powershell/
  * @copyright Copyright (c) 2017 Ran Cohen <rannn505@outlook.com>
  * @license MIT (http://www.opensource.org/licenses/mit-license.php)
- * @Compiled At: 2017-9-1
+ * @Compiled At: 2017-9-4
   *********************************************************/
 'use strict';
 

--- a/src/Shell.js
+++ b/src/Shell.js
@@ -68,8 +68,15 @@ export class Shell extends eventEmitter {
 
     this._proc.stdout.on('data', data => {
       if(data.indexOf(EOI) !== -1) {
-        if (data.indexOf(os.EOL+EOI) !== -1) {
-          var correctedData = data.replace(os.EOL+EOI,'');
+        // noticed a strange bug the occationally instead of getting the \r\n that was expected on Windows I would only get \n
+        // from what I could tell using Write-Host would produce only a \n about 95% of the time but echo always produced \r\n
+        if (data.indexOf("\r\n"+EOI) !== -1) {
+          var correctedData = data.replace("\r\n"+EOI,'');
+          this.emit('output', correctedData);
+          _output.push(correctedData);
+        }
+        else if (data.indexOf("\n"+EOI) !== -1) {
+          var correctedData = data.replace("\n"+EOI,'');
           this.emit('output', correctedData);
           _output.push(correctedData);
         }

--- a/src/Shell.js
+++ b/src/Shell.js
@@ -68,7 +68,7 @@ export class Shell extends eventEmitter {
 
     this._proc.stdout.on('data', data => {
       if(data.indexOf(EOI) !== -1) {
-        if (data.indexOf(os.EOL+EOI)) {
+        if (data.indexOf(os.EOL+EOI) !== -1) {
           var correctedData = data.replace(os.EOL+EOI,'');
           this.emit('output', correctedData);
           _output.push(correctedData);

--- a/src/Shell.js
+++ b/src/Shell.js
@@ -10,7 +10,7 @@ const IS_WIN      = os.platform() === 'win32';
 const MODULE_MSG  = colors.bold.blue(`NPS> `);
 const OK_MSG      = colors.green;
 const ERROR_MSG   = colors.red;
-const EOI         = 'EOI';
+const EOI         = '4ab5852ddbe5489dbbb4249b3b032ce4';
 
 
 /**
@@ -68,6 +68,12 @@ export class Shell extends eventEmitter {
 
     this._proc.stdout.on('data', data => {
       if(data.indexOf(EOI) !== -1) {
+        if (data.indexOf(os.EOL+EOI)) {
+          var correctedData = data.replace(os.EOL+EOI,'');
+          this.emit('output', correctedData);
+          _output.push(correctedData);
+        }
+
         this.emit(_type, _output.join(''));
         _output = [];
         _type = '_resolve';


### PR DESCRIPTION
On some systems about 80% of the time I was not getting the expected returned value when running invoke. This was caused by stdout combining lines of output, so instead of first getting the output from the command and then getting the EOI output, we would get the output of the command and EOI combined in 1 stream (string) separated by a line return. This would cause invoke to return a blank string or only a part of the output.

Also changed EOI string to a guid so that there is a smaller chance of this occurring in script output.

Issue #20 and #26 reference this behaviour