### PR TITLE
Add windowsHide to the spawn options

### DIFF
--- a/dist/Shell.js
+++ b/dist/Shell.js
@@ -105,7 +105,7 @@ var Shell = exports.Shell = function (_EventEmitter) {
     }
 
     // the PowerShell process
-    _this._proc = spawn('powershell' + (IS_WIN ? '.exe' : ''), args, { stdio: 'pipe' });
+    _this._proc = spawn('powershell' + (IS_WIN ? '.exe' : ''), args, { stdio: 'pipe', windowsHide: true });
 
     // Make sure the PS process start successfully
     if (!_this._proc.pid) {

--- a/src/Shell.js
+++ b/src/Shell.js
@@ -51,7 +51,7 @@ export class Shell extends EventEmitter {
     }
 
     // the PowerShell process
-    this._proc = spawn(`powershell${IS_WIN ? '.exe' : ''}`, args, { stdio: 'pipe' });
+    this._proc = spawn(`powershell${IS_WIN ? '.exe' : ''}`, args, { stdio: 'pipe', windowsHide: true });
 
     // Make sure the PS process start successfully
     if(!this._proc.pid) {


### PR DESCRIPTION
On windows the powershell prompt can appear (in my case when I spawned a node process not in a shell, so no shell existed), unless you pass the "windowsHide" parameter.