### PR TITLE
Loads assets using HTTPS

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -9,7 +9,7 @@
   <title>node-powershell</title>
 
   <!-- Flatdoc -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/legacy.js'></script>
   <script src='https://cdn.rawgit.com/rstacruz/flatdoc/v0.9.0/flatdoc.js'></script>
 
@@ -44,7 +44,7 @@
     </div>
     <div class='right'>
       <!-- GitHub buttons: see http://ghbtns.com -->
-      <iframe src="http://ghbtns.com/github-btn.html?user=rannn505&amp;repo=node-powershell&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
+      <iframe src="https://ghbtns.com/github-btn.html?user=rannn505&amp;repo=node-powershell&amp;type=watch&amp;count=true" allowtransparency="true" frameborder="0" scrolling="0" width="110" height="20"></iframe>
     </div>
   </div>
 


### PR DESCRIPTION
The documentation website is currently not working, because its assets fail to load

```
Mixed Content: The page at 'https://cdn.rawgit.com/rannn505/node-powershell/236b6c3a/docs/docs.html' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.
```