### PR TITLE
fix: prevent emitting error event twice

### DIFF
--- a/lib/Shell.js
+++ b/lib/Shell.js
@@ -66,13 +66,17 @@ class Shell extends EventEmitter {
     const proc = spawn(`${psProc}${!isWin ? '' : '.exe'}`, psOpts, { stdio: 'pipe' });
     this.pid = proc.pid;
 
+    proc.once('error', () => {
+      // if this.pid is absent an error will already have been emitted
+      if (this.pid) this.emit('error', new PS_PROC_ERROR());
+    });
+
     // make sure the PS process start successfully
     if(!this.pid) {
       this.emit('error', new PS_PROC_ERROR());
+      return;
     }
-    proc.once('error', () => {
-      this.emit('error', new PS_PROC_ERROR());
-    });
+
 
     // set streams encoding
     proc.stdin.setDefaultEncoding(options.inputEncoding || 'utf8');


### PR DESCRIPTION
On my linux system where powershell is absent I had an uncaught exception. This is because the this.pid check emitted an error, then the proc.once('error') emitted another one. I added a simple check to prevent this from happening.