### PR TITLE
Fix trim unix eol in buffer on windows

### DIFF
--- a/packages/buffer-trim/lib/index.ts
+++ b/packages/buffer-trim/lib/index.ts
@@ -1,8 +1,7 @@
-import { EOL } from 'os';
-
-const eol = EOL.charCodeAt(0);
+const bn = '\n'.charCodeAt(0);
+const br = '\r'.charCodeAt(0);
 const space = ' '.charCodeAt(0);
-export const isWhitespaceByte = (byte: number): boolean => byte === eol || byte === space;
+export const isWhitespaceByte = (byte: number): boolean => byte === bn || byte === br || byte === space;
 
 export const trimBufferStart = (buf: Buffer): Buffer => {
   let start = 0;


### PR DESCRIPTION
Without this fix all run end up with error output as result and hasError flag true.
The content of the error output before this fix is unix style eol.

Solves issue: https://github.com/rannn505/node-powershell/issues/122