### PR TITLE
invoke() cannot be resolved in some cases

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,7 @@ class ShellStreamBuffer extends Writable {
   }
   _write(chunk, encoding, cb) {
     // console.log(`${this.chunksArray.length} - ${chunk.toString()}`);
-    if(chunk.compare(this.EOI) === 0) {
+    if(chunk.toString().includes(this.EOI)) {
       cb();
       return this.emit('EOI');
     }


### PR DESCRIPTION
The output of the invoked commands may be concatenated to the output of the EOI writing command. In some situations, the chunk passed in the _write() function contains not only the EOI string but also the output of the previously executed command. This issue will make the invoke function is stuck and never be resolved. Instead of comparing the chunk with the EOI string, I suggest checking if the chunk containing the EOI string.